### PR TITLE
Set upper limit for aiohttp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["SignalR", "SignalR client", "Real-time messaging"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-aiohttp = "^3.6.0"
+aiohttp = ">=3.6.0,<3.11.0"
 msgpack = "^1.0.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This ensures that aiohttp can only be up to 3.10.*, and cannot use 3.11.0 or above